### PR TITLE
fix: update stakeholder query URL

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -3,4 +3,4 @@ DATABASE_SCHEMA={SCHEMA}
 DATABASE_URL_SEEDER=postgresql://m_{SCHEMA}:{SEEDER_PASSWORD}@db-postgresql-sfo2-nextgen-do-user-1067699-0.db.ondigitalocean.com:25060/treetracker?ssl=no-verify
 NODE_LOG_LEVEL=debug
 TREETRACKER_API_URL=https://dev-k8s.treetracker.org/treetracker
-REACT_APP_STAKEHOLDER_API_ROOT=https://dev-k9s.treetracker.org/stakeholders
+TREETRACKER_STAKEHOLDER_API_URL=https://dev-k8s.treetracker.org/stakeholder

--- a/server/services/StakeholderService.js
+++ b/server/services/StakeholderService.js
@@ -2,7 +2,7 @@ const axios = require('axios').default;
 
 const TREETRACKER_STAKEHOLDER_API_URL =
   `${process.env.TREETRACKER_STAKEHOLDER_API_URL}/stakeholders` ||
-  'http://treetracker-stakeholder-api.stakeholder-api/stakeholders';
+  'hthttps://dev-k8s.treetracker.org/stakeholder/stakeholders';
 
 const getStakeholderById = async (id) => {
   const response = await axios.get(

--- a/server/services/StakeholderService.js
+++ b/server/services/StakeholderService.js
@@ -2,7 +2,7 @@ const axios = require('axios').default;
 
 const TREETRACKER_STAKEHOLDER_API_URL =
   `${process.env.TREETRACKER_STAKEHOLDER_API_URL}/stakeholders` ||
-  'hthttps://dev-k8s.treetracker.org/stakeholder/stakeholders';
+  'https://dev-k8s.treetracker.org/stakeholder/stakeholders';
 
 const getStakeholderById = async (id) => {
   const response = await axios.get(

--- a/server/services/StakeholderService.js
+++ b/server/services/StakeholderService.js
@@ -2,7 +2,7 @@ const axios = require('axios').default;
 
 const TREETRACKER_STAKEHOLDER_API_URL =
   `${process.env.TREETRACKER_STAKEHOLDER_API_URL}/stakeholders` ||
-  'https://dev-k8s.treetracker.org/stakeholder/stakeholders';
+  'http://treetracker-stakeholder-api.stakeholder-api/stakeholders';
 
 const getStakeholderById = async (id) => {
   const response = await axios.get(


### PR DESCRIPTION
## Description
The earnings API doesn't query the proper URL for stakeholders, leading to grower names being returned as `undefined`. The URL has been updated and queries correctly.

**Issue(s) addressed**
- Resolves [ Earnings: Name of growers are all undefined #1092 ](https://github.com/Greenstand/treetracker-admin-client/issues/1092) from [treetracker-admin-client]( https://github.com/Greenstand/treetracker-admin-client ).
- Resolves #116  

**What kind of change(s) does this PR introduce?**
- [ ] Enhancement
- [X] Bug fix
- [ ] Refactor

**Please check if the PR fulfils these requirements**

- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Issue

**What is the current behavior?**
The earnings model doesn't contain the grower name as an attribute, it contains `worker_id` only. The earnings API calls the function `getStakeHolderById()` (in `/server/services/StakeholderService.js`), which queries the stakeholder API  to retrieve the grower name. Currently, the stakeholder API URL is incorrect, as well as the name of the environment variable which stores the URL value. So, the grower's first and last name are returned as `undefined`. 


**What is the new behavior?**
The grower's name is retrieved correctly from the correct query URL.

## Breaking change

**Does this PR introduce a breaking change?**
No.

## Other useful information
None.
